### PR TITLE
BUG: tag should be unique

### DIFF
--- a/MRML/vtkMRMLLongPETCTReportNode.h
+++ b/MRML/vtkMRMLLongPETCTReportNode.h
@@ -73,7 +73,7 @@ class VTK_SLICER_LONGPETCT_MODULE_MRML_EXPORT vtkMRMLLongPETCTReportNode : publi
   virtual void Copy(vtkMRMLNode *node);
 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "Report";};
+  virtual const char* GetNodeTagName() {return "LongitudinalPETCTReport";};
 
   void Initialize();
 


### PR DESCRIPTION
Need to use more descriptive tags. This tag was clashing with the one in Reporting module, and as a result the Reporting MRML node was not registered. 
