### PR TITLE
BUG: Fix runtime error related to missing EditorWidget

### DIFF
--- a/Py/qSlicerLongitudinalPETCTModuleWidget.py
+++ b/Py/qSlicerLongitudinalPETCTModuleWidget.py
@@ -1,5 +1,6 @@
 from __main__ import vtk, qt, ctk, slicer
 
+from Editor import EditorWidget
 from SlicerLongitudinalPETCTModuleViewHelper import SlicerLongitudinalPETCTModuleViewHelper as ViewHelper
 from SlicerLongitudinalPETCTModuleSegmentationHelper import SlicerLongitudinalPETCTModuleSegmentationHelper as SegmentationHelper
 


### PR DESCRIPTION
This commit fixes a regression most likely introduced by r24155 (ENH: Fixes

Error fixed by this commit is the following:

//-------------
File "/home/jcfr/.config/NA-MIC/Extensions-24305/LongitudinalPETCT/lib/Slicer-4.4/qt-loadable-modules/Python/qSlicerLongitudinalPETCTModuleWidget.py", line 99, in __createEditorWidget
  self.editorWidget = EditorWidget(editorWidgetParent, False)
NameError: global name 'EditorWidget' is not defined
//-------------
